### PR TITLE
Make output redirection overwrite target file instead of appending to it

### DIFF
--- a/fork-exec/1.15/sample.c
+++ b/fork-exec/1.15/sample.c
@@ -71,7 +71,7 @@ void execute_command_line(struct command *cmd_struct, int num_pipes)
 			{
 				int new_fds = open(
 					cmd_struct[i].output_redir,
-					O_APPEND | O_WRONLY | O_CREAT,
+					O_TRUNC | O_WRONLY | O_CREAT,
 					S_IRWXU);
 				dup2(new_fds, STDOUT_FILENO);
 				close(new_fds);


### PR DESCRIPTION
This change will cause the output redirection operator ">" to behave more like the one in a "normal" shell.